### PR TITLE
[ BUGS-5985 ] - Dynamic class properties cause deprecation notices in php 8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bats
 bin
 libexec
 share
+/.idea

--- a/src/Commands/MysqlSlowCommand.php
+++ b/src/Commands/MysqlSlowCommand.php
@@ -25,8 +25,20 @@ class MysqlSlowCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
     use StructuredListTrait;
 
+    /**
+     * @var
+     */
     private $site;
+
+    /**
+     * @var
+     */
     private $environment;
+
+    /**
+     * @var string
+     */
+    private $logPath;
 
     /**
      * Object constructor
@@ -160,7 +172,7 @@ class MysqlSlowCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function DefineSiteEnv($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env);
+        [$this->site, $this->environment] = $this->getSiteEnv($site_env);
     }
 
     /**

--- a/src/Commands/NginxAccessCommand.php
+++ b/src/Commands/NginxAccessCommand.php
@@ -25,8 +25,19 @@ class NginxAccessCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
     use StructuredListTrait;
 
+    /**
+     * @var
+     */
     private $site;
+
+    /**
+     * @var
+     */
     private $environment;
+
+    /**
+     * @var string
+     */
     private $logPath;
 
     /**
@@ -313,7 +324,7 @@ class NginxAccessCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function DefineSiteEnv($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env);
+        [$this->site, $this->environment] = $this->getSiteEnv($site_env);
     }
 
     /**

--- a/src/Commands/NginxErrorCommand.php
+++ b/src/Commands/NginxErrorCommand.php
@@ -25,8 +25,20 @@ class NginxErrorCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
     use StructuredListTrait;
 
+    /**
+     * @var
+     */
     private $site;
+
+    /**
+     * @var
+     */
     private $environment;
+
+    /**
+     * @var string
+     */
+    private $logPath;
 
     /**
      * Object constructor
@@ -161,7 +173,7 @@ class NginxErrorCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function DefineSiteEnv($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env);
+        [$this->site, $this->environment] = $this->getSiteEnv($site_env);
     }
 
     /**

--- a/src/Commands/PhpErrorCommand.php
+++ b/src/Commands/PhpErrorCommand.php
@@ -25,8 +25,20 @@ class PhpErrorCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
     use StructuredListTrait;
 
+    /**
+     * @var
+     */
     private $site;
+
+    /**
+     * @var
+     */
     private $environment;
+
+    /**
+     * @var string
+     */
+    private $logPath;
 
     /**
      * Object constructor
@@ -224,7 +236,7 @@ class PhpErrorCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function DefineSiteEnv($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env);
+        [$this->site, $this->environment] = $this->getSiteEnv($site_env);
     }
 
     /**

--- a/src/Commands/PhpFpmErrorCommand.php
+++ b/src/Commands/PhpFpmErrorCommand.php
@@ -25,8 +25,20 @@ class PhpFpmErrorCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
     use StructuredListTrait;
 
+    /**
+     * @var
+     */
     private $site;
+
+    /**
+     * @var
+     */
     private $environment;
+
+    /**
+     * @var string
+     */
+    private $logPath;
 
     /**
      * Object constructor
@@ -247,7 +259,7 @@ class PhpFpmErrorCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function DefineSiteEnv($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env);
+        [$this->site, $this->environment] = $this->getSiteEnv($site_env);
     }
 
     /**

--- a/src/Commands/PhpSlowCommand.php
+++ b/src/Commands/PhpSlowCommand.php
@@ -25,8 +25,20 @@ class PhpSlowCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
     use StructuredListTrait;
 
+    /**
+     * @var
+     */
     private $site;
+
+    /**
+     * @var
+     */
     private $environment;
+
+    /**
+     * @var string
+     */
+    private $logPath;
 
     /**
      * Object constructor
@@ -178,7 +190,7 @@ class PhpSlowCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function DefineSiteEnv($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env);
+        [$this->site, $this->environment] = $this->getSiteEnv($site_env);
     }
 
     /**

--- a/src/Commands/SiteLogsCommand.php
+++ b/src/Commands/SiteLogsCommand.php
@@ -30,8 +30,25 @@ class SiteLogsCommand extends TerminusCommand implements SiteAwareInterface
     use SiteAwareTrait;
     use StructuredListTrait;
 
+    /**
+     * @var
+     */
     private $site;
+
+    /**
+     * @var
+     */
     private $environment;
+
+    /**
+     * @var false|string
+     */
+    private $width;
+
+    /**
+     * @var string
+     */
+    private $logPath;
 
     /**
      * Object constructor
@@ -44,6 +61,9 @@ class SiteLogsCommand extends TerminusCommand implements SiteAwareInterface
         $this->logPath = getenv('HOME') . '/.terminus/site-logs';
     }
 
+    /**
+     * @var string[]
+     */
     private $logs_filename = [
         'nginx-access',
         'nginx-error',
@@ -654,10 +674,15 @@ class SiteLogsCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function DefineSiteEnv($site_env)
     {
-        list($this->site, $this->environment) = $this->getSiteEnv($site_env);
+        [$this->site, $this->environment] = $this->getSiteEnv($site_env);
     }
 
-    public function NewRelicHealthCheck($site_env) 
+    /**
+     * @param $site_env
+     *
+     * @return void
+     */
+    public function NewRelicHealthCheck($site_env)
     {
         $this->DefineSiteEnv($site_env);
         $site = $this->site->get('name');
@@ -825,7 +850,7 @@ class SiteLogsCommand extends TerminusCommand implements SiteAwareInterface
      */
     private function checkSiteHeaders($site_env)
     {
-        list(, $env) = $this->getSiteEnv($site_env);
+        [, $env] = $this->getSiteEnv($site_env);
         $domains = $env->getDomains()->filter(
             function ($domain) {
                 return $domain->get('type') === 'custom';


### PR DESCRIPTION
Dynamic class properties are deprecated in php 8.2