### PR TITLE
Recurse into subdirectories when using --all to fix broken appserver log downloading

### DIFF
--- a/src/Commands/SiteLogsCommand.php
+++ b/src/Commands/SiteLogsCommand.php
@@ -150,7 +150,7 @@ class SiteLogsCommand extends TerminusCommand implements SiteAwareInterface
             if ($options['all'])
             {
                 $this->log()->notice('Running {cmd}', ['cmd' => "rsync $rsync_options $src@$app_server_ip:logs/* $dir"]);
-                $this->passthru("rsync $rsync_options -zi --progress --ipv4 --exclude=.git -e 'ssh -p 2222' $src@$app_server_ip:logs/* $dir $devnull");
+                $this->passthru("rsync $rsync_options -zir --progress --ipv4 --exclude=.git -e 'ssh -p 2222' $src@$app_server_ip:logs/* $dir $devnull");
             }
             else
             {


### PR DESCRIPTION
When running some bulk log download scripts which use `terminus logs:get [site].[env] --all` , I noticed that appserver logs are not being downloaded. This is because when using the --all function, the -r option is required for rsync to recurse into appserver logs/* subdirectories such as php and nginx. This PR provides the fix