### PR TITLE
fix: pin workflow actions to commit SHAs and restrict permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: PHP Compatibility
+
+permissions:
+  contents: read
+
 on:
   push
 
@@ -8,9 +12,9 @@ jobs:
     name: PHP Compatibility
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: PHPCompatibility
-        uses: pantheon-systems/phpcompatibility-action@v1
+        uses: pantheon-systems/phpcompatibility-action@7bf1b2881e207c80ad4569874ceee225f59537d1 # v1.1.1
         with:
           test-versions: 7.4-
   checkdeprecations:
@@ -18,9 +22,9 @@ jobs:
     name: Check for deprecations
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: 8.4
       - name: Check for deprecations


### PR DESCRIPTION
## Summary

Addresses GHAS code scanning alerts in `.github/workflows/ci.yml`:
- **4x `actions/unpinned-tag`** — pinned all actions to immutable commit SHAs
- **2x `actions/missing-workflow-permissions`** — added `permissions: contents: read` at workflow level

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` (phpcompatibility job) | `@v2` | `@ee0669bd` (v2) |
| `pantheon-systems/phpcompatibility-action` | `@v1` | `@7bf1b288` (v1.1.1) |
| `actions/checkout` (checkdeprecations job) | `@v4` | `@34e11487` (v4) |
| `shivammathur/setup-php` | `@v2` | `@accd6127` (v2) |

No functional changes — same action versions, now pinned to immutable SHAs.